### PR TITLE
[WORKAROUND] Make SM images fallback work again

### DIFF
--- a/Classes/Hook/MetaTagGeneratorHook.php
+++ b/Classes/Hook/MetaTagGeneratorHook.php
@@ -52,10 +52,9 @@ class MetaTagGeneratorHook
     {
         $metaData = GeneralUtility::makeInstance(MetaDataService::class)->getMetaData();
 
-        # following if statement prevents getting the fallback SM images
-        //if (!$metaData) {
-        //    return;
-        //}
+        if (!$metaData) {
+           $metaData = [];
+        }
 
         // render content
         $this->renderContent($metaData);


### PR DESCRIPTION
Use empty array for metaData if none was found. With empty array given, the fallback social media images from TS constants are used.